### PR TITLE
remove deprecated authenticate event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+
+- Stop sending deprecated `authenticate` event
+
 ## [0.1.4] - 2022-01-06
 
 ### Fixed

--- a/src/API.ts
+++ b/src/API.ts
@@ -44,7 +44,6 @@ export type ServerMessages = {
 };
 
 export type ClientMessages = {
-  authenticate: [Participant & { token: string }, { success: true }];
   join: [
     { callId: string; token: string },
     {

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -65,19 +65,12 @@ class RoomClient {
   > = {};
   private emitter: Emitter<Events>;
 
-  static async connect(
-    call: {
-      id: string;
-      url: string;
-      token: string;
-    },
-    user: Participant
-  ): Promise<RoomClient> {
+  static async connect(call: {
+    id: string;
+    url: string;
+    token: string;
+  }): Promise<RoomClient> {
     const client = await Client.connect(call.url);
-    client.emit("authenticate", {
-      ...user,
-      token: call.token,
-    });
 
     // Request to join the room.
     const {

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -103,13 +103,10 @@ const useConnectCall = ({
   // create a client for the call
   useEffect(() => {
     if (call?.id === undefined) return;
-    RoomClient.connect(
-      { id: call.id, url: call.url, token: call.token },
-      authInfo
-    )
+    RoomClient.connect({ id: call.id, url: call.url, token: call.token })
       .then(setClient)
       .catch(handleError);
-  }, [call?.id, call?.url, call?.token, authInfo]);
+  }, [call?.id, call?.url, call?.token]);
 
   useEffect(() => {
     if (!client) return;


### PR DESCRIPTION
The server stopped implementing `authenticate` in the JWT transition, and now we no longer need to send it.