### PR TITLE
make caller responsible for producing tracks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- useConnectCall returns a `produceTrack` function that may be called when status has reached `connected`.
+
+### Removed
+
+- Producing audio and video tracks automatically during connection
+
 ## [0.2.1] - 2022-02-02
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Stop sending deprecated `authenticate` event
 
+## [0.2.0] - 2022-01-12
+
+### Added
+
+- Voice calls do not attempt to produce video
+
 ## [0.1.4] - 2022-01-06
 
 ### Fixed

--- a/src/__mocks__/MediaDevices.ts
+++ b/src/__mocks__/MediaDevices.ts
@@ -1,12 +1,13 @@
 export default {
   getUserMedia: (constraints: { audio: any } | { video: any }) => {
     if ("audio" in constraints) {
-      return { id: "audio", getAudioTracks: () => [] };
+      return { id: "audio", getAudioTracks: () => [{ kind: "audio" }] };
     }
     return {
       id: "video",
       getVideoTracks: () => [
         {
+          kind: "video",
           getSettings: jest.fn().mockReturnValue({ width: 400, height: 300 }),
         },
       ],


### PR DESCRIPTION
Previously `useConnectCall` took the liberty of automatically producing a video and audio track during the connection process. Now it is the responsibility of the caller.

This was the only way I could see to support react-native-webrtc without adding the dependency for web clients. It also removes the need to understand call types and user roles, because all of that is effectively pushed out to the caller.

Long term this should also make it easier to provide controls for users to choose audio or video devices.