### PR TITLE
stop asking for unused authInfo.token

### DIFF
--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -21,7 +21,7 @@ type Props = {
     url: string;
     token: string;
   };
-  authInfo: Participant & { token: string };
+  authInfo: Participant;
   onPeerConnected?: (user: Participant) => void;
   onPeerDisconnected?: (user: Participant) => void;
   onTimer?: (


### PR DESCRIPTION
This is a remnant from when CVH used Malan session tokens.