### PR TITLE
return a disconnect() function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- useConnectCall returns a disconnect() function that may be called to end the connection without unmounting
+
 ## [0.6.0] - 2022-04-04
+
+### Added
 
 - set simulcast spatial layer 0 to 50kbps/10fps
 - add `ConnectionMonitor` which periodically reports changes in connection state

--- a/src/useConnectCall.test.ts
+++ b/src/useConnectCall.test.ts
@@ -431,4 +431,14 @@ describe("useConnectCall", () => {
     });
     expect(onTimer).toHaveBeenCalledTimes(1);
   });
+
+  it("disconnects manually", async () => {
+    const { result } = renderHook(() =>
+      useConnectCall({ call, authInfo, onTimer })
+    );
+    await waitFor(() => expect(result.current.status).toBe("connected"));
+
+    await result.current.disconnect();
+    expect(result.current.status).toBe("disconnected");
+  });
 });


### PR DESCRIPTION
Applications may want to tear down the video call state without unmounting whatever component calls `useConnectCall`. The `disconnect()` function aims to provide that ability. It also means a new ClientState.

## TODO

- [x] verify the behavior in an integrated application