### PR TITLE
implement heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `user.id` prop for useConnectCall
 - rely on CVH for role (was: userType) information
+- client-side heartbeat for monitor role
 
 ## [0.8.1] - 2022-05-09
 

--- a/src/API.ts
+++ b/src/API.ts
@@ -81,6 +81,7 @@ export type ClientMessages = {
     { success: true }
   ];
   finishConnecting: [{ callId: string }, { success: true }];
+  heartbeat: [Record<string, never>, Record<string, never>];
   produce: [
     { callId: string; kind: MediaKind; rtpParameters: RtpParameters },
     { producerId: string }

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -84,6 +84,7 @@ class RoomClient {
     ping: NaN,
     videoDisabled: false,
   };
+  private heartbeat?: NodeJS.Timer;
 
   static async connect(call: {
     id: string;
@@ -277,6 +278,12 @@ class RoomClient {
       }
     });
 
+    if (this.role === "monitor") {
+      this.heartbeat = setInterval(() => {
+        client.emit("heartbeat", {});
+      }, 1000);
+    }
+
     // now that our handlers are prepared, we're reading to begin consuming
     void client.emit("finishConnecting", { callId });
   }
@@ -332,6 +339,7 @@ class RoomClient {
   }
 
   async close() {
+    if (this.heartbeat) clearInterval(this.heartbeat);
     this.client.close();
     this.consumerTransport.close();
     this.producerTransport?.close();


### PR DESCRIPTION
I've come to believe that our heartbeat implementation is [redundant with socket.io's protocol](https://socket.io/blog/engine-io-4-release/#heartbeat-mechanism-reversal). Nevertheless, it seems easier to implement support now rather than gather buy-in for the change to CVH.