### PR TITLE
build CommonJS for Jest compatibility

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -10,6 +10,7 @@
     "outDir": "lib",
     "sourceMap": true,
     "declaration": true,
-    "noEmit": false
+    "noEmit": false,
+    "module": "CommonJS"
   }
 }


### PR DESCRIPTION
I confirmed locally that this fixes the need for `jest.transformIgnorePatterns` when running Jest tests in the host application.