### PR TITLE
remove source maps from compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- build CommonJS for Jest compatibility
+- remove source maps from build
+
 ## [0.9.1] - 2022-06-03
 
 - compatibility with any React version 17.0.1 or greater

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,7 +8,7 @@
   ],
   "compilerOptions": {
     "outDir": "lib",
-    "sourceMap": true,
+    "sourceMap": false,
     "declaration": true,
     "noEmit": false,
     "module": "CommonJS"


### PR DESCRIPTION
Source maps create confusion (and warnings) without the accompanying source. However, shipping the source to an unknown toolchain does not make sense. Removing source maps will mean that stack traces blame the compiled code, which seems acceptable.