### PR TITLE
Add debounce delay for react strict mode compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "connect-call-client",
       "version": "0.9.2",
       "license": "GPL-3.0",
       "dependencies": {

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -151,9 +151,19 @@ const useConnectCall = ({
     [setConnectionState, localVideo]
   );
 
+  const [debounceReady, setDebounceReady] = useState(false);
+
+  useEffect(() => {
+    const debounceTimeout = setTimeout(() => {
+      setDebounceReady(true);
+    }, 10);
+    return () => clearTimeout(debounceTimeout);
+  }, []);
+
   // create a client for the call
   useEffect(() => {
     if (call?.id === undefined) return;
+    if (!debounceReady) return;
     RoomClient.connect({
       id: call.id,
       url: call.url,
@@ -161,7 +171,7 @@ const useConnectCall = ({
     })
       .then(setClient)
       .catch(handleError);
-  }, [call?.id, call?.url, call?.token]);
+  }, [call?.id, call?.url, call?.token, debounceReady]);
 
   const disconnect = useCallback(async () => {
     if (!client) return;


### PR DESCRIPTION
In react strict mode, components get rendered twice. This caused a problem in `ameelio-web` where `useConnectCall` was called twice and, when the first room was `close()`-d, the new room's produce got interrupted. Adds a 10ms delay to `useConnectCall` before actually attempting to connect to avoid this.