### PR TITLE
fix scalabilityMode with VP8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- fix simulcast configuration in new versions of Chrome
+
 ## [0.9.3] - 2022-11-02
 
 - avoid race condition in development with React Strict mode

--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ npm install connect-call-client
 import { useConnectCall } from 'connect-call-client';
 ```
 
+## Integration Testing
+
+Due to issues with `npm link` and nested node_modules/, it's recommendeded to build a release package and try it locally in a useful host application:
+
+1. Add a `-rcN` suffix to the package.json version
+2. Create a NPM package: `npm run build && npm pack`
+3. From the host application: `npm install path/to/connect-call-client-a.b.c-rcN.tgz`
+
 ## Releasing
 
 1. Review `CHANGELOG.md` and determine the next semantic version

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -19,17 +19,17 @@ const config: Record<MediaKind, ProducerOptions> = {
         rid: "r0",
         maxBitrate: 50000,
         maxFramerate: 10,
-        scalabilityMode: "S1T3",
+        scalabilityMode: "L1T3",
       },
       {
         rid: "r1",
         maxBitrate: 300000,
-        scalabilityMode: "S1T3",
+        scalabilityMode: "L1T3",
       },
       {
         rid: "r2",
         maxBitrate: 900000,
-        scalabilityMode: "S1T3",
+        scalabilityMode: "L1T3",
       },
     ],
     codecOptions: {


### PR DESCRIPTION
I began receiving the following error during test calls. It appears to represent an incompatibility with Chrome. I relaunched Chrome recently and am now running v111. Older versions may not yet experience problems.

> Produce error: DOMException: Failed to execute 'addTransceiver' on 'RTCPeerConnection': Attempted to set RtpParameters scalabilityMode to an unsupported value for the current codecs.

According to https://w3c.github.io/webrtc-svc/#scalabilitymodes*, `S1T3` is not a valid identifier. According to the naming convention, `S1` would mean "1 spatial layer" which is equivalent to `L1`. Thus `L1T3` appears to be the correct identifier. This is further corroborated by recent updates to mediasoup-demo's simulcast configuration.