### PR TITLE
Track initial status

### DIFF
--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -645,6 +645,10 @@ class RoomClient {
       ...(reason ? { reason: reason } : {}),
     });
   }
+
+  getPeers() {
+    return Object.values(this.peers);
+  }
 }
 
 export default RoomClient;

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -271,6 +271,7 @@ class RoomClient {
 
     // Listen for new joiners
     client.on("joined", async ({ id, role, status }) => {
+      console.log("Got joined event", id, role, status);
       if (!this.peers[id]) {
         this.peers[id] = {
           user: { id, role },
@@ -294,6 +295,7 @@ class RoomClient {
       const consumer = await consumerTransport.consume(options);
 
       if (!this.peers[user.id]) {
+        console.log("Got consume event", user);
         this.peers[user.id] = {
           user,
           consumers: {},

--- a/src/testFactories.ts
+++ b/src/testFactories.ts
@@ -19,7 +19,9 @@ export function clientFactory() {
     sendServerEvent: <E extends keyof ServerMessages>(
       name: E,
       data: ServerMessages[E]
-    ) => emitter.emit(name, data),
+    ) => {
+      emitter.emit(name, data);
+    },
 
     prepareServerResponse: <E extends keyof ClientMessages>(
       name: E,
@@ -31,7 +33,12 @@ export function clientFactory() {
     off: emitter.off,
     emit: jest
       .fn()
-      .mockImplementation((name: keyof ClientMessages) => emitResponses[name]),
+      .mockImplementation(
+        (name: keyof ClientMessages) =>
+          new Promise((resolve, reject) =>
+            setTimeout(() => resolve(emitResponses[name]), 50)
+          )
+      ),
     close: jest.fn(),
 
     connectionMonitor: connectionMonitorFactory(),

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -162,6 +162,7 @@ const useConnectCall = ({
     connectionState,
     status,
   }: Peer) => {
+    console.log("handling peer update", user, status);
     setPeers((peers) => {
       return [
         ...peers.filter((p) => p.user.id !== user.id),
@@ -248,6 +249,7 @@ const useConnectCall = ({
     })
       .then((client) => {
         setClient(client);
+        setPeers(client.getPeers());
         setTrackedUser(client.user);
       })
       .catch(handleError);

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -162,7 +162,6 @@ const useConnectCall = ({
     connectionState,
     status,
   }: Peer) => {
-    console.log("handling peer update", user, status);
     setPeers((peers) => {
       return [
         ...peers.filter((p) => p.user.id !== user.id),


### PR DESCRIPTION
Took a while to figure out what was causing this. The initial `status` of peers is sent over in the `joined` event, which is sent immediately after the `join` request is made with good credentials, _before_ the request is even responded to or the rest of the handshake is done. This means that the `RoomClient` has not initialized yet when the `joined` event fires and we don't hear about the initial status of peers.

I tried a couple workarounds and this one seemed to require the least refactoring -- we listen for `joined` events before sending `join` and "stage" them so that they can be responded to immediately once the `RoomClient` is done handshaking.