### PR TITLE
Expose paused states of streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.4] - 2023-03-14
+
 - fix simulcast configuration in new versions of Chrome
 
 ## [0.9.3] - 2022-11-02

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-call-client",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "client for the connect-call platform",
   "license": "GPL-3.0",
   "main": "lib/index.js",

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -50,7 +50,7 @@ export type Peer = {
   user: Participant;
   stream: MediaStream;
   screenshareStream: MediaStream;
-  pausedStates: { [label: ParticipantLabel]: boolean };
+  pausedStates: Partial<Record<ProducerLabel, boolean>>;
   connectionState: ConnectionState;
   status: UserStatus[];
 };
@@ -279,6 +279,7 @@ class RoomClient {
           stream: new MediaStream(),
           screenshareStream: new MediaStream(),
           status,
+          pausedStates: {},
           connectionState: { quality: "unknown", ping: NaN },
         };
         this.emitter.emit("onPeerConnect", { id, role });
@@ -408,6 +409,7 @@ class RoomClient {
             stream: new MediaStream(),
             screenshareStream: new MediaStream(),
             status: status,
+            pausedStates: {},
             connectionState: { quality: "unknown", ping: NaN },
           };
         }

--- a/src/useConnectCall.test.ts
+++ b/src/useConnectCall.test.ts
@@ -228,12 +228,10 @@ describe("useConnectCall", () => {
         onNewMessage,
       })
     );
-    console.log(result.current.peers);
 
     await waitFor(() => expect(result.current.status).toBe("connected"));
 
     expect(result.current.peers).toMatchInlineSnapshot(`Array []`);
-    console.log(result.current.peers);
 
     act(() =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -244,7 +242,6 @@ describe("useConnectCall", () => {
         paused: false,
       } as any)
     );
-    console.log(result.current.peers);
     await waitFor(() => expect(result.current.peers).toHaveLength(1));
     expect(result.current.peers).toMatchInlineSnapshot(`
       Array [

--- a/src/useConnectCall.test.ts
+++ b/src/useConnectCall.test.ts
@@ -228,15 +228,23 @@ describe("useConnectCall", () => {
         onNewMessage,
       })
     );
+    console.log(result.current.peers);
 
     await waitFor(() => expect(result.current.status).toBe("connected"));
 
     expect(result.current.peers).toMatchInlineSnapshot(`Array []`);
+    console.log(result.current.peers);
 
     act(() =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      client.sendServerEvent("consume", { user, kind: "audio" } as any)
+      client.sendServerEvent("consume", {
+        user,
+        kind: "audio",
+        label: "audio",
+        paused: false,
+      } as any)
     );
+    console.log(result.current.peers);
     await waitFor(() => expect(result.current.peers).toHaveLength(1));
     expect(result.current.peers).toMatchInlineSnapshot(`
       Array [
@@ -244,6 +252,9 @@ describe("useConnectCall", () => {
           "connectionState": Object {
             "ping": NaN,
             "quality": "unknown",
+          },
+          "pausedStates": Object {
+            "audio": false,
           },
           "screenshareStream": MediaStream {
             "tracks": Array [],
@@ -268,7 +279,12 @@ describe("useConnectCall", () => {
 
     act(() =>
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      client.sendServerEvent("consume", { user, kind: "video" } as any)
+      client.sendServerEvent("consume", {
+        user,
+        kind: "video",
+        label: "video",
+        paused: false,
+      } as any)
     );
     await waitFor(() =>
       expect(result.current.peers[0].stream.getTracks()).toHaveLength(2)
@@ -279,6 +295,57 @@ describe("useConnectCall", () => {
           "connectionState": Object {
             "ping": NaN,
             "quality": "unknown",
+          },
+          "pausedStates": Object {
+            "audio": false,
+            "video": false,
+          },
+          "screenshareStream": MediaStream {
+            "tracks": Array [],
+          },
+          "status": Array [],
+          "stream": MediaStream {
+            "tracks": Array [
+              Object {
+                "kind": "audio",
+              },
+              Object {
+                "kind": "video",
+              },
+            ],
+          },
+          "user": Object {
+            "detail": undefined,
+            "id": "USER-01",
+            "role": "visitParticipant",
+            "type": "user",
+          },
+        },
+      ]
+    `);
+
+    act(() =>
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      client.sendServerEvent("consume", {
+        user,
+        kind: "video",
+        label: "video",
+        paused: false,
+      } as any)
+    );
+    await waitFor(() =>
+      expect(result.current.peers[0].stream.getTracks()).toHaveLength(2)
+    );
+    expect(result.current.peers).toMatchInlineSnapshot(`
+      Array [
+        Object {
+          "connectionState": Object {
+            "ping": NaN,
+            "quality": "unknown",
+          },
+          "pausedStates": Object {
+            "audio": false,
+            "video": false,
           },
           "screenshareStream": MediaStream {
             "tracks": Array [],
@@ -308,6 +375,7 @@ describe("useConnectCall", () => {
       client.sendServerEvent("producerUpdate", {
         from: user,
         paused: true,
+        label: "video",
         type: "video",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
       } as any)
@@ -321,6 +389,10 @@ describe("useConnectCall", () => {
           "connectionState": Object {
             "ping": NaN,
             "quality": "unknown",
+          },
+          "pausedStates": Object {
+            "audio": false,
+            "video": true,
           },
           "screenshareStream": MediaStream {
             "tracks": Array [],

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -164,7 +164,6 @@ const useConnectCall = ({
     pausedStates,
     status,
   }: Peer) => {
-    console.log("handling peer update", user, status);
     setPeers((peers) => {
       return [
         ...peers.filter((p) => p.user.id !== user.id),

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -109,6 +109,7 @@ const useConnectCall = ({
       stream: MediaStream;
       screenshareStream: MediaStream;
       connectionState: ConnectionState;
+      pausedStates: Partial<Record<ProducerLabel, boolean>>;
       status: UserStatus[];
     }[]
   >([]);
@@ -160,6 +161,7 @@ const useConnectCall = ({
     stream,
     screenshareStream,
     connectionState,
+    pausedStates,
     status,
   }: Peer) => {
     console.log("handling peer update", user, status);
@@ -171,6 +173,7 @@ const useConnectCall = ({
           stream,
           screenshareStream,
           connectionState,
+          pausedStates,
           status,
         },
       ];


### PR DESCRIPTION
Formerly we detected whether a participant was muted by checking whether the audio track existed. This fails to distinguish between _paused_ audio and _broken_ audio. Since we're modifying connect-call-client now anyway I figured we should expose information about consumer paused states to fix this.