### PR TITLE
Respect server mutes immediately

### DIFF
--- a/src/API.ts
+++ b/src/API.ts
@@ -23,6 +23,7 @@ export enum ParticipantEventDetail {
 export enum Role {
   visitParticipant = "visitParticipant",
   webinarAttendee = "webinarAttendee",
+  webinarIsolatedAttendee = "webinarIsolatedAttendee",
   webinarHost = "webinarHost",
   monitor = "monitor",
 }

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -573,7 +573,6 @@ class RoomClient {
     if (!this.producers.audio) return;
     // Do not allow resuming audio when remote muted
     if (this.user.status.includes(UserStatus.AudioMutedByServer)) {
-      console.log("Refusing to unmute due to current status");
       return;
     }
     await this.updateProducer(this.producers.audio, false);

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -572,7 +572,10 @@ class RoomClient {
   async resumeAudio() {
     if (!this.producers.audio) return;
     // Do not allow resuming audio when remote muted
-    if (this.user.status.includes(UserStatus.AudioMutedByServer)) return;
+    if (this.user.status.includes(UserStatus.AudioMutedByServer)) {
+      console.log("Refusing to unmute due to current status");
+      return;
+    }
     await this.updateProducer(this.producers.audio, false);
   }
 

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -440,7 +440,7 @@ const useConnectCall = ({
       if (label === ProducerLabel.audio) {
         setLocalAudio({
           stream,
-          paused: false,
+          paused: !client.user.status.includes(UserStatus.AudioMutedByServer),
         });
       }
       if (label === ProducerLabel.video) {
@@ -451,7 +451,7 @@ const useConnectCall = ({
           videoWidth && videoHeight ? videoHeight / videoWidth : undefined;
         setLocalVideo({
           stream,
-          paused: false,
+          paused: !client.user.status.includes(UserStatus.VideoMutedByServer),
           aspectRatio,
         });
       }

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -360,6 +360,7 @@ const useConnectCall = ({
     if (!client) throw new Error("Not connected");
     if (localAudio?.paused === undefined)
       throw new Error("Not producing audio");
+    console.log("Toggling audio; currently is", localAudio.paused);
     localAudio.paused ? await client.resumeAudio() : await client.pauseAudio();
   }, [client, localAudio?.paused]);
 
@@ -440,7 +441,7 @@ const useConnectCall = ({
       if (label === ProducerLabel.audio) {
         setLocalAudio({
           stream,
-          paused: !client.user.status.includes(UserStatus.AudioMutedByServer),
+          paused: client.user.status.includes(UserStatus.AudioMutedByServer),
         });
       }
       if (label === ProducerLabel.video) {
@@ -451,7 +452,7 @@ const useConnectCall = ({
           videoWidth && videoHeight ? videoHeight / videoWidth : undefined;
         setLocalVideo({
           stream,
-          paused: !client.user.status.includes(UserStatus.VideoMutedByServer),
+          paused: client.user.status.includes(UserStatus.VideoMutedByServer),
           aspectRatio,
         });
       }

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -364,7 +364,6 @@ const useConnectCall = ({
     if (!client) throw new Error("Not connected");
     if (localAudio?.paused === undefined)
       throw new Error("Not producing audio");
-    console.log("Toggling audio; currently is", localAudio.paused);
     localAudio.paused ? await client.resumeAudio() : await client.pauseAudio();
   }, [client, localAudio?.paused]);
 

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -41,6 +41,7 @@ type Props = {
     msElapsed: number
   ) => void;
   onNewMessage?: (message: Message) => void;
+  disableFrux?: boolean;
 };
 
 export type Message = {
@@ -93,6 +94,7 @@ const useConnectCall = ({
   onPeerConnected,
   onPeerDisconnected,
   onTimer,
+  disableFrux,
   onNewMessage,
 }: Props): ConnectCall => {
   const [client, setClient] = useState<RoomClient>();
@@ -219,6 +221,8 @@ const useConnectCall = ({
 
   const handleConnectionState = useCallback(
     (connectionState: ConnectionState) => {
+      if (disableFrux) return;
+
       setConnectionState(connectionState);
       if (localVideo && connectionState.videoDisabled && !localVideo.paused) {
         setLocalVideo({


### PR DESCRIPTION
The client mute status should always track the server mute status. We might be initialized with the server mute status on, which caused a problem because the tracking only responded to changes and initialized unmuted. Fixes this by initializing muted.

TODO in a later PR: figure out how to handle the fact that non-hosts are probably forbidden from screensharing.