### PR TITLE
Automatically close producer when track ends

### DIFF
--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -518,8 +518,14 @@ class RoomClient {
       track,
       appData: { label },
     });
-
     this.producers[label] = producer;
+
+    track.addEventListener("ended", () => {
+      const producer = this.producers[label];
+      if (producer && producer.track === track) {
+        this.closeProducer(label);
+      }
+    });
   }
 
   async closeProducer(label: ProducerLabel): Promise<void> {

--- a/src/__mocks__/MediaDevices.ts
+++ b/src/__mocks__/MediaDevices.ts
@@ -2,7 +2,15 @@ export default {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   getUserMedia: (constraints: { audio: any } | { video: any }) => {
     if ("audio" in constraints) {
-      return { id: "audio", getAudioTracks: () => [{ kind: "audio" }] };
+      return {
+        id: "audio",
+        getAudioTracks: () => [
+          {
+            kind: "audio",
+            addEventListener: jest.fn(),
+          },
+        ],
+      };
     }
     return {
       id: "video",
@@ -10,6 +18,7 @@ export default {
         {
           kind: "video",
           getSettings: jest.fn().mockReturnValue({ width: 400, height: 300 }),
+          addEventListener: jest.fn(),
         },
       ],
     };

--- a/src/__mocks__/MediaStream.ts
+++ b/src/__mocks__/MediaStream.ts
@@ -1,4 +1,7 @@
-type MediaStreamTrack = { kind: "audio" } | { video: "video" };
+type MediaStreamTrack = {
+  kind: "audio" | "video";
+  addEventListener: (event: string, handler: any) => void;
+};
 
 export default class MediaStream {
   private tracks: MediaStreamTrack[] = [];


### PR DESCRIPTION
I noticed that once I started screensharing I couldn't stop. That's what `closeProducer` was for but nobody ever called it. This will call it when the track ends, which will happen when a user clicks "stop screensharing" in the native browser UI.