### PR TITLE
Allow disabling frux before client is initialized

### DIFF
--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -124,7 +124,7 @@ const useConnectCall = ({
 
   useEffect(() => {
     if (client) client.disableFrux = disableFrux;
-  }, [disableFrux]);
+  }, [disableFrux, client]);
 
   const [trackedUser, setTrackedUser] = useState<{
     id: string;


### PR DESCRIPTION
Previously a missing useEffect dependencies meant that `setDisableFrux` did nothing if called too early.