### PR TITLE
Separate monitor join/disconnect events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "connect-call-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@testing-library/jest-dom": "^5.15.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "connect-call-client",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "client for the connect-call platform",
   "license": "GPL-3.0",
   "main": "lib/index.js",

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -81,6 +81,8 @@ type Events = {
   onPeerConnect: Participant;
   onPeerDisconnect: Participant;
   onPeerUpdate: Peer;
+  onMonitorJoin: string;
+  onMonitorDisconnect: string;
   onProducerUpdate: {
     producerId: string;
     paused: boolean;
@@ -102,6 +104,8 @@ class RoomClient {
       consumers: Partial<Record<ProducerLabel, Consumer>>;
     }
   > = {};
+  // We don't actually know anything about a monitor except their id.
+  private monitors: Set<string> = new Set();
   public user: {
     id: string;
     role: Role;
@@ -313,21 +317,26 @@ class RoomClient {
       role: Role;
       status: UserStatus[];
     }) => {
-      if (!this.peers[id]) {
-        this.peers[id] = {
-          user: { id, role },
-          consumers: {},
-          stream: new MediaStream(),
-          screenshareStream: new MediaStream(),
-          status,
-          pausedStates: {},
-          connectionState: { quality: "unknown", ping: NaN },
-        };
-        this.emitter.emit("onPeerConnect", { id, role });
-      }
+      if (role === Role.monitor) {
+        this.monitors.add(id);
+        this.emitter.emit("onMonitorJoin", id);
+      } else {
+        if (!this.peers[id]) {
+          this.peers[id] = {
+            user: { id, role },
+            consumers: {},
+            stream: new MediaStream(),
+            screenshareStream: new MediaStream(),
+            status,
+            pausedStates: {},
+            connectionState: { quality: "unknown", ping: NaN },
+          };
+          this.emitter.emit("onPeerConnect", { id, role });
+        }
 
-      this.peers[id].status = status;
-      this.emitter.emit("onPeerUpdate", this.peers[id]);
+        this.peers[id].status = status;
+        this.emitter.emit("onPeerUpdate", this.peers[id]);
+      }
     };
 
     // Respond to staged joined events
@@ -437,6 +446,9 @@ class RoomClient {
         peer.consumers.video?.close();
         delete this.peers[user.id];
         this.emitter.emit("onPeerDisconnect", user);
+      } else if (this.monitors.has(user.id)) {
+        this.monitors.delete(user.id);
+        this.emitter.emit("onMonitorDisconnect", user.id);
       }
     });
 

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -69,6 +69,7 @@ export type ConnectCall = {
     label: ProducerLabel
   ) => Promise<void>;
   peers: Peer[];
+  monitors: string[];
   messages: Message[];
   sendMessage: (contents: string) => Promise<void>;
   setPreferredSimulcastLayer: (x: {
@@ -121,6 +122,7 @@ const useConnectCall = ({
       status: UserStatus[];
     }[]
   >([]);
+  const [monitors, setMonitors] = useState<string[]>([]);
 
   useEffect(() => {
     if (client) client.disableFrux = disableFrux;
@@ -189,6 +191,14 @@ const useConnectCall = ({
         },
       ];
     });
+  };
+
+  const handleMonitorJoin = (id: string) => {
+    setMonitors([...monitors.filter((x) => x !== id), id]);
+  };
+
+  const handleMonitorDisconnect = (id: string) => {
+    setMonitors(monitors.filter((x) => x !== id));
   };
 
   const handleUserUpdate = (user: {
@@ -309,6 +319,8 @@ const useConnectCall = ({
     if (!client) return;
     client.on("onPeerDisconnect", handlePeerDisconnect);
     client.on("onPeerUpdate", handlePeerUpdate);
+    client.on("onMonitorJoin", handleMonitorJoin);
+    client.on("onMonitorDisconnect", handleMonitorDisconnect);
     client.on("onUserUpdate", handleUserUpdate);
     client.on("onStatusChange", handleStatusChange);
     client.on("onTextMessage", handleTextMessage);
@@ -524,6 +536,7 @@ const useConnectCall = ({
     messages,
     sendMessage,
     disconnect,
+    monitors,
 
     // Operations
     textMessage,


### PR DESCRIPTION
As per discussion in slack. Stores monitors in a separate array; only stores ids because monitors don't really have any other state (streams, statuses).