### PR TITLE
JR/SC-5939/add monitor alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Announce monitor join events
+
 ## [1.3.0] - 2023-04-21
 
 - Joining monitors are now put into a different array from `peers`.

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -33,6 +33,7 @@ type Props = {
     token: string;
   };
   user: Pick<Participant, "id">;
+  onMonitorJoined?: (monitor: Participant) => void;
   onPeerConnected?: (user: Participant) => void;
   onPeerDisconnected?: (user: Participant) => void;
   onTimer?: (
@@ -98,6 +99,7 @@ export type ConnectCall = {
 const useConnectCall = ({
   call,
   user,
+  onMonitorJoined,
   onPeerConnected,
   onPeerDisconnected,
   onTimer,
@@ -338,6 +340,13 @@ const useConnectCall = ({
       client.off("onConnectionState", handleConnectionState);
     };
   }, [client, handleTimer, handleConnectionState]);
+
+  // announce monitor joins
+  useEffect(() => {
+    if (!client || !onMonitorJoined) return;
+    client.on("onMonitorJoin", onMonitorJoined);
+    return () => client.off("onMonitorJoin", onMonitorJoined);
+  }, [client, onMonitorJoined]);
 
   // announce peer connects
   useEffect(() => {

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -33,7 +33,7 @@ type Props = {
     token: string;
   };
   user: Pick<Participant, "id">;
-  onMonitorJoined?: (monitor: Participant) => void;
+  onMonitorJoined?: (monitor: string) => void;
   onPeerConnected?: (user: Participant) => void;
   onPeerDisconnected?: (user: Participant) => void;
   onTimer?: (

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -33,7 +33,7 @@ type Props = {
     token: string;
   };
   user: Pick<Participant, "id">;
-  onMonitorJoined?: (monitor: string) => void;
+  onMonitorJoined?: (user: string) => void;
   onPeerConnected?: (user: Participant) => void;
   onPeerDisconnected?: (user: Participant) => void;
   onTimer?: (


### PR DESCRIPTION
I believe will need this support to enable monitorJoined events in ameelio web? Since monitors have been moved out of peers that callback isn't getting invoked anymore when a peer connects (yay!) But I still need to show the toast to the webinar host when the monitor joins so I hope this PR represents a necessary update.