### PR TITLE
JR/SC-6233/paused should consider track enabled too

### DIFF
--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -500,7 +500,7 @@ const useConnectCall = ({
           stream,
           paused:
             client.user.status.includes(UserStatus.AudioMutedByServer) ||
-            !track.enabled,
+            track.enabled === false, // Only consider explicit false
         });
       }
       if (label === ProducerLabel.video) {
@@ -513,7 +513,7 @@ const useConnectCall = ({
           stream,
           paused:
             client.user.status.includes(UserStatus.VideoMutedByServer) ||
-            !track.enabled,
+            track.enabled === false, // Only consider explicit false
           aspectRatio,
         });
       }

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -498,7 +498,9 @@ const useConnectCall = ({
       if (label === ProducerLabel.audio) {
         setLocalAudio({
           stream,
-          paused: client.user.status.includes(UserStatus.AudioMutedByServer),
+          paused:
+            client.user.status.includes(UserStatus.AudioMutedByServer) ||
+            !track.enabled,
         });
       }
       if (label === ProducerLabel.video) {
@@ -509,7 +511,9 @@ const useConnectCall = ({
           videoWidth && videoHeight ? videoHeight / videoWidth : undefined;
         setLocalVideo({
           stream,
-          paused: client.user.status.includes(UserStatus.VideoMutedByServer),
+          paused:
+            client.user.status.includes(UserStatus.VideoMutedByServer) ||
+            !track.enabled,
           aspectRatio,
         });
       }


### PR DESCRIPTION
Accompanies https://github.com/Ameelio/ameelio-web/pull/598. This will also set `localAudio` or `localVideo` to `paused` if the track is not enabled (previously just considered server mutes).