### PR TITLE
Disable simulcast for screenshares

### DIFF
--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -28,8 +28,17 @@ const unknownConnectionState = {
   badConnection: false,
 };
 
-const config: Record<MediaKind, ProducerOptions> = {
-  video: {
+const config: Record<ProducerLabel, ProducerOptions> = {
+  [ProducerLabel.screenshare]: {
+    encodings: [
+      {
+        rid: "r0",
+        maxBitrate: 900000,
+      },
+    ],
+    codecOptions: {},
+  },
+  [ProducerLabel.video]: {
     encodings: [
       {
         rid: "r0",
@@ -52,7 +61,7 @@ const config: Record<MediaKind, ProducerOptions> = {
       videoGoogleStartBitrate: 1000,
     },
   },
-  audio: {},
+  [ProducerLabel.audio]: {},
 };
 
 export type Peer = {
@@ -378,7 +387,7 @@ class RoomClient {
       throw new Error(`RoomClient is already producing ${label}`);
 
     const producer = await this.producerTransport.produce({
-      ...config[track.kind as MediaKind],
+      ...config[label],
       track,
       appData: { label, startPaused: !track.enabled },
     });


### PR DESCRIPTION
This _seems_ to work to fix the black-screen screenshare issue. After making this change I haven't seen it again.

I also tried duplicating the stream by painting it onto a canvas and then reading it off the canvas. That didn't help; only this did.

Theories for what's going on: there may be some issue with how simulcast relates to videos with strange dimensions. Possibly related to the following Chromium bug: https://bugs.chromium.org/p/webrtc/issues/detail?id=11310. This bug is purportedly fixed, so I'm not sure; but it seems plausible that something slipped through and we're experiencing the same.