### PR TITLE
Handle disconnects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Automatically recover socket disconnects due to network issues, by renegotiating mediasoup connection
+- Allow manual recovery of disconnections due to other clients joining with `manuallyReconnect`
+- Expose disconnect reason with `disconnectReason`
+
 ## [2.1.0]
 
 ## MINOR

--- a/src/API.ts
+++ b/src/API.ts
@@ -8,6 +8,7 @@ import {
 
 export enum DisconnectReason {
   error = "error",
+  roomClose = "roomClose",
   connectedElsewhere = "connectedElsewhere",
 }
 

--- a/src/API.ts
+++ b/src/API.ts
@@ -6,6 +6,11 @@ import {
   TransportOptions,
 } from "mediasoup-client/lib/types";
 
+export enum DisconnectReason {
+  error = "error",
+  connectedElsewhere = "connectedElsewhere",
+}
+
 export enum ConnectionStateQuality {
   excellent = "excellent",
   good = "good",
@@ -100,6 +105,8 @@ export type ServerMessages = {
   };
   timer: { name: "maxDuration"; msRemaining: number; msElapsed: number };
   state: PublishedRoomState;
+  manualDisconnect: DisconnectReason;
+  disconnect: string; // This is not actually a server message but is still a socket.on() handler
 };
 
 export type ClientMessages = {

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -199,12 +199,7 @@ class RoomClient {
 
     // Respond to unintentional disconnect
     client.on("disconnect", (reason: string) => {
-      if (
-        ![
-          "server namespace disconnect",
-          "client namespace disconnect",
-        ].includes(reason)
-      ) {
+      if (!["io server disconnect", "io client disconnect"].includes(reason)) {
         this.emitter.emit("disconnect", DisconnectReason.error);
       }
     });

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -185,6 +185,8 @@ const useConnectCall = ({
 
     // When we disconnect, reinitialize
     client.on("disconnect", (reason: DisconnectReason) => {
+      if (client) client.close();
+
       setClient(undefined);
       setDisconnectReason(reason);
       if (reason === DisconnectReason.error) {

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -341,7 +341,7 @@ const useConnectCall = ({
     return () => {
       setClientStatus(ClientStatus.disconnected);
     };
-  }, [client, disconnect]);
+  }, [client]);
 
   const sendMessage = useCallback(
     async (contents: string) => {

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -322,7 +322,7 @@ const useConnectCall = ({
   const disconnect = useCallback(async () => {
     if (!client) return;
     setClientStatus(ClientStatus.disconnected);
-    client.close();
+    client.close(true); // Also stop user media grab
   }, [client]);
 
   const closeProducer = useCallback(
@@ -338,7 +338,9 @@ const useConnectCall = ({
   useEffect(() => {
     if (!client) return;
     setClientStatus(ClientStatus.connected);
-    return () => void disconnect();
+    return () => {
+      setClientStatus(ClientStatus.disconnected);
+    };
   }, [client, disconnect]);
 
   const sendMessage = useCallback(


### PR DESCRIPTION
1. Whenever socket.io disconnects and reconnects, also shut down old mediasoup streams and creating new ones.
2. Add provisions for manual disconnection where the server can send a reason. When this happens, don't automatically reconnect, but force the application layer to call `manuallyReconnect`, which will presumably be activated by a user action.