### PR TITLE
Use track.enabled to pause/resume while not connected

### DIFF
--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -345,6 +345,14 @@ const useConnectCall = ({
     };
   }, [client]);
 
+  useEffect(() => {
+    if (!client) return;
+    setClientStatus(ClientStatus.connected);
+    return () => {
+      setClientStatus(ClientStatus.disconnected);
+    };
+  }, [client]);
+
   const sendMessage = useCallback(
     async (contents: string) => {
       if (!client) throw new Error("Not connected");

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -402,16 +402,20 @@ const useConnectCall = ({
       if (client) {
         await client.pauseProducer(label);
       } else {
-        const stream = localProducers[label]?.stream;
+        const producer = localProducers[label];
 
-        if (!stream) throw new Error("No such producer");
+        if (!producer) throw new Error("No such producer");
 
         const track =
           label === ProducerLabel.audio
-            ? stream.getAudioTracks()[0]
-            : stream.getVideoTracks()[0];
+            ? producer.stream.getAudioTracks()[0]
+            : producer.stream.getVideoTracks()[0];
 
         track.enabled = false;
+        setLocalProducers({
+          ...localProducers,
+          [label]: { stream: producer.stream, paused: true },
+        });
       }
     },
     [client]
@@ -422,16 +426,20 @@ const useConnectCall = ({
       if (client) {
         await client.resumeProducer(label);
       } else {
-        const stream = localProducers[label]?.stream;
+        const producer = localProducer[label];
 
-        if (!stream) throw new Error("No such producer");
+        if (!producer) throw new Error("No such producer");
 
         const track =
           label === ProducerLabel.audio
-            ? stream.getAudioTracks()[0]
-            : stream.getVideoTracks()[0];
+            ? producer.stream.getAudioTracks()[0]
+            : producer.stream.getVideoTracks()[0];
 
         track.enabled = true;
+        setLocalProducers({
+          ...localProducers,
+          [label]: { stream: producer.stream, paused: false },
+        });
       }
     },
     [client]

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -426,7 +426,7 @@ const useConnectCall = ({
       if (client) {
         await client.resumeProducer(label);
       } else {
-        const producer = localProducer[label];
+        const producer = localProducers[label];
 
         if (!producer) throw new Error("No such producer");
 

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -386,16 +386,40 @@ const useConnectCall = ({
 
   const pauseProducer = useCallback(
     async (label: ProducerLabel) => {
-      if (!client) throw new Error("Not connected");
-      await client.pauseProducer(label);
+      if (client) {
+        await client.pauseProducer(label);
+      } else {
+        const stream = localProducers[label]?.stream;
+
+        if (!stream) throw new Error("No such producer");
+
+        const track =
+          label === ProducerLabel.audio
+            ? stream.getAudioTracks()[0]
+            : stream.getVideoTracks()[0];
+
+        track.enabled = false;
+      }
     },
     [client]
   );
 
   const resumeProducer = useCallback(
     async (label: ProducerLabel) => {
-      if (!client) throw new Error("Not connected");
-      await client.resumeProducer(label);
+      if (client) {
+        await client.resumeProducer(label);
+      } else {
+        const stream = localProducers[label]?.stream;
+
+        if (!stream) throw new Error("No such producer");
+
+        const track =
+          label === ProducerLabel.audio
+            ? stream.getAudioTracks()[0]
+            : stream.getVideoTracks()[0];
+
+        track.enabled = true;
+      }
     },
     [client]
   );


### PR DESCRIPTION
[sc-6483]

For some operations, like messaging, it makes sense to just disable it while you don't have internet. For others, like video/audio mute/unmute, one can imagine that a user might need to do this while disconnected (especially muting) with the expectation that the change gets applied when they reconnect. This PR should make this possible.