### PR TITLE
Fix callback dependency issue caught by lint

### DIFF
--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -418,7 +418,7 @@ const useConnectCall = ({
         });
       }
     },
-    [client]
+    [client, localProducers]
   );
 
   const resumeProducer = useCallback(
@@ -442,7 +442,7 @@ const useConnectCall = ({
         });
       }
     },
-    [client]
+    [client, localProducers]
   );
 
   // Operations


### PR DESCRIPTION
Trying to make this part of 2.4.0; lint caught a missing hook dependency that I think could've caused problems.