### PR TITLE
JR/close producer on mute event

### DIFF
--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -418,7 +418,19 @@ class RoomClient {
       producer,
     };
 
+    // The `ended` event of the MediaStreamTrack interface is fired
+    // when playback or streaming has stopped because the end of
+    // the media was reached or because no further data is available.
     track.addEventListener("ended", () => {
+      const localProducer = this.localProducers[label];
+      if (localProducer && localProducer.producer.track === track) {
+        this.closeProducer(label);
+      }
+    });
+
+    // The `mute` event is sent to a MediaStreamTrack when the track's source
+    // is temporarily unable to provide media data.
+    track.addEventListener("mute", () => {
       const localProducer = this.localProducers[label];
       if (localProducer && localProducer.producer.track === track) {
         this.closeProducer(label);


### PR DESCRIPTION
Inspired by:

<img width="1262" alt="Screenshot 2024-03-26 at 5 27 50 PM copy 2" src="https://github.com/Ameelio/connect-call-client/assets/5834080/66d7ff69-ff94-4f7a-94fa-3fff65fef3f3">

I want to add support for an event handler for the `mute` event.