### PR TITLE
disable/enable connection monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## MINOR
+
+- `disableConnectionMonitoring` and `enableConnectionMonitoring` may be used to disable the latency timer when timers are known to be unreliable
+
 ## [2.4.0]
 
 ## MINOR

--- a/src/ConnectionMonitor.ts
+++ b/src/ConnectionMonitor.ts
@@ -59,6 +59,7 @@ export default class ConnectionMonitor {
     this.interval = interval;
     this.emitter = mitt();
     this.socket.on("disconnect", () => {
+      this.emitter.all.clear();
       this.stop();
     });
   }
@@ -133,23 +134,20 @@ export default class ConnectionMonitor {
    * starts the monitor
    */
   start() {
-    if (!this.timer) {
-      this.socket.on(PONG_EVENT, this.handleResponse);
-      this.timer = setInterval(() => {
-        this.update();
-      }, this.interval);
-    }
+    if (this.timer) return; // already started
+    this.socket.on(PONG_EVENT, this.handleResponse);
+    this.timer = setInterval(() => {
+      this.update();
+    }, this.interval);
   }
 
   /**
    * stops the monitor
    */
   stop() {
-    if (this.timer) {
-      this.emitter.all.clear();
-      this.socket.off(PONG_EVENT, this.handleResponse);
-      clearInterval(this.timer);
-      this.timer = undefined;
-    }
+    if (!this.timer) return; // already stopped
+    this.socket.off(PONG_EVENT, this.handleResponse);
+    clearInterval(this.timer);
+    this.timer = undefined;
   }
 }

--- a/src/RoomClient.ts
+++ b/src/RoomClient.ts
@@ -118,7 +118,6 @@ class RoomClient {
   > = {};
   private consumers: Map<string, { consumer: Consumer; stream: MediaStream }> =
     new Map();
-  private peers: Record<string, Peer> = {};
   public user: {
     id: string;
     role: Role;
@@ -220,6 +219,14 @@ class RoomClient {
 
   enableFrux() {
     this.fruxEnabled = true;
+  }
+
+  enableConnectionMonitoring() {
+    this.client.connectionMonitor.start();
+  }
+
+  disableConnectionMonitoring() {
+    this.client.connectionMonitor.stop();
   }
 
   on<E extends keyof Events>(name: E, handler: (data: Events[E]) => void) {

--- a/src/useConnectCall.ts
+++ b/src/useConnectCall.ts
@@ -69,6 +69,8 @@ export type ConnectCall = {
   enableFrux: () => void;
   remoteLowerHand: (targetUserId: string) => Promise<void>;
   disconnect: () => Promise<void>;
+  enableConnectionMonitoring: () => void;
+  disableConnectionMonitoring: () => void;
 
   // Debugging only
   simulatePingLatency: (ping: number) => void;
@@ -522,13 +524,21 @@ const useConnectCall = ({
     },
     [client]
   );
-
   const resumeConsumer = useCallback(
     async (peerId: string, label: ProducerLabel) => {
       if (client) await client.resumeConsumer(peerId, label);
     },
     [client]
   );
+
+  const enableConnectionMonitoring = useCallback(() => {
+    if (!client) throw new Error("Not connected");
+    return client.enableConnectionMonitoring();
+  }, [client]);
+  const disableConnectionMonitoring = useCallback(() => {
+    if (!client) throw new Error("Not connected");
+    return client.disableConnectionMonitoring();
+  }, [client]);
 
   return {
     // Connection and room status
@@ -579,9 +589,10 @@ const useConnectCall = ({
     lowerHand,
     remoteLowerHand,
     setPreferredSimulcastLayer,
-
     pauseConsumer,
     resumeConsumer,
+    enableConnectionMonitoring,
+    disableConnectionMonitoring,
 
     // Debugging
     simulatePingLatency,


### PR DESCRIPTION
The connection monitoring system depends on promises and timers that can become unreliable when the page is hidden. We need the option to stop measuring ping latency.

I considered solving this all internally without any changes to the public API, but realized that we can't assume connect-call-client is operating in a browser. 